### PR TITLE
Refactor tabnav

### DIFF
--- a/js/modules/accordion.js
+++ b/js/modules/accordion.js
@@ -5,8 +5,8 @@ export default class Accordion {
   }
 
   toggleAccordion(item) {
-    item.classList.add(this.activeClass);
-    item.nextElementSibling.classList.add(this.activeClass);
+    item.classList.toggle(this.activeClass);
+    item.nextElementSibling.classList.toggle(this.activeClass);
   }
 
   addAccordionEvent() {
@@ -21,4 +21,4 @@ export default class Accordion {
       this.addAccordionEvent();
     }
   }
-} 
+}

--- a/js/modules/scroll-animation.js
+++ b/js/modules/scroll-animation.js
@@ -2,11 +2,11 @@ import debounce from "./debounce.js";
 
 export default function initAnimationScroll() {
   const sections = document.querySelectorAll('[data-anime="scroll"]');
+  const windowHalf = window.innerHeight * 0.6;
 
   function animaScroll() {
     sections.forEach((section) => {
       const sectionTop = section.getBoundingClientRect().top;
-      const windowHalf = window.innerHeight * 0.6;
       const isSectionVisible = sectionTop - windowHalf < 0;
       if (isSectionVisible) {
         section.classList.add("active");

--- a/js/modules/tabnav.js
+++ b/js/modules/tabnav.js
@@ -1,22 +1,30 @@
-export default function initTabNav() {
-  const tabMenu = document.querySelectorAll('[data-tab="menu"] li');
-  const tabContent = document.querySelectorAll('[data-tab="content"] section');
-
-  function activeTab(index) {
-    tabContent.forEach((section) => {
-      section.classList.remove("active");
-    });
-    const direction = tabContent[index].dataset.anime;
-    tabContent[index].classList.add("active", direction);
+export default class TabNav {
+  constructor(menu, content) {
+    this.tabMenu = document.querySelectorAll(menu);
+    this.tabContent = document.querySelectorAll(content);
+    this.activeClass = "active";
   }
 
-  if (tabMenu.length && tabContent.length) {
-    tabContent[0].classList.add("active");
+  activeTab(index) {
+    this.tabContent.forEach((section) => {
+      section.classList.remove(this.activeClass);
+    });
+    const direction = this.tabContent[index].dataset.anime;
+    this.tabContent[index].classList.add(this.activeClass, direction);
   }
 
-  tabMenu.forEach((itemMenu, index) => {
-    itemMenu.addEventListener("click", () => {
-      activeTab(index);
+  addTabNavEvent() {
+    this.tabMenu.forEach((itemMenu, index) => {
+      itemMenu.addEventListener("click", () => {
+        this.activeTab(index);
+      });
     });
-  });
+  }
+
+  init() {
+    if (this.tabMenu.length && this.tabContent.length) {
+      this.activeTab(0);
+      this.addTabNavEvent();
+    }
+  }
 }

--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,6 @@
 import ScrollSuave from "./modules/scroll-suave.js";
 import Accordion from "./modules/accordion.js";
-import initTabNav from "./modules/tabnav.js";
+import TabNav from "./modules/tabnav.js";
 import initModal from "./modules/modal.js";
 import initTooltip from "./modules/tooltip.js";
 import initDropdownMenu from "./modules/dropdown-menu.js";
@@ -15,7 +15,12 @@ scrollSuave.init();
 const accordion = new Accordion('[data-anime="accordion"] dt');
 accordion.init();
 
-initTabNav();
+const tabNav = new TabNav(
+  '[data-tab="menu"] li',
+  '[data-tab="content"] section'
+);
+tabNav.init();
+
 initModal();
 initTooltip();
 initDropdownMenu();

--- a/js/script.js
+++ b/js/script.js
@@ -8,6 +8,7 @@ import initMenuMobile from "./modules/menu-mobile.js";
 import initOperation from "./modules/operation.js";
 import initFetchAnimals from "./modules/fetch-animals.js";
 import initFetchBitcoin from "./modules/fetch-bitcoin.js";
+import initAnimationScroll from "./modules/scroll-animation.js";
 
 const scrollSuave = new ScrollSuave('[data-menu="suave"] a[href^="#"]');
 scrollSuave.init();
@@ -28,3 +29,4 @@ initMenuMobile();
 initOperation();
 initFetchAnimals();
 initFetchBitcoin();
+initAnimationScroll()


### PR DESCRIPTION
Converts the tab navigation from a functional module to a class-based implementation, adding a constructor, explicit activeTab logic, event binding, and an explicit init flow. Also initializes the first tab and wires up click handling via a dedicated method, improving maintainability and reusability.

Updates the accordion toggle to use class toggling for both header and content, aligning with the new tab navigation approach and preventing duplicate class logic.

Script wiring updated to instantiate the new TabNav class with selectors and call init, making the tab system consistent with the rest of the modules.

fix: restore scroll animation accidentally removed