### PR TITLE
Refactors mobile menu to class-based API

### DIFF
--- a/js/modules/menu-mobile.js
+++ b/js/modules/menu-mobile.js
@@ -1,23 +1,38 @@
 import outsideClick from "./outsideclick.js";
 
-export default function initMenuMobile() {
-  const menuButton = document.querySelector('[data-menu="button"]');
-  const menuList = document.querySelector('[data-menu="list"]');
-  const events = ["click", "touchstart"];
+export default class MenuMobile {
+  constructor(menuButton, menuList, events) {
+    this.menuButton = document.querySelector(menuButton);
+    this.menuList = document.querySelector(menuList);
+    this.activeClass = "active";
+    this.openMenu = this.openMenu.bind(this);
 
-  function openMenu(event) {
-    event.preventDefault();
-    menuList.classList.add("active");
-    menuButton.classList.add("active");
-    outsideClick(menuList, events, () => {
-      menuList.classList.remove("active");
-      menuButton.classList.remove("active");
+    if (events === undefined) {
+      this.events = ["touchstart", "click"];
+    } else {
+      this.events = events;
+    }
+  }
+
+  openMenu() {
+    this.menuList.classList.add(this.activeClass);
+    this.menuButton.classList.add(this.activeClass);
+    outsideClick(this.menuList, this.events, () => {
+      this.menuList.classList.remove(this.activeClass);
+      this.menuButton.classList.remove(this.activeClass);
     });
   }
 
-  if (menuButton) {
-    events.forEach((event) => {
-      menuButton.addEventListener(event, openMenu);
-    });
+  addMenuMobileEvents() {
+    this.events.forEach((event) =>
+      this.menuButton.addEventListener(event, this.openMenu)
+    );
+  }
+
+  init() {
+    if (this.menuButton && this.menuList) {
+      this.addMenuMobileEvents();
+    }
+    return this;
   }
 }

--- a/js/script.js
+++ b/js/script.js
@@ -4,12 +4,11 @@ import TabNav from "./modules/tabnav.js";
 import Modal from "./modules/modal.js";
 import Tooltip from "./modules/tooltip.js";
 import DropdownMenu from "./modules/dropdown-menu.js";
-import initMenuMobile from "./modules/menu-mobile.js";
+import MenuMobile from "./modules/menu-mobile.js";
 import initOperation from "./modules/operation.js";
 import fetchAnimals from "./modules/fetch-animals.js";
 import fetchBitcoin from "./modules/fetch-bitcoin.js";
 import ScrollAnimation from "./modules/scroll-animation.js";
-
 
 const scrollSuave = new ScrollSuave('[data-menu="suave"] a[href^="#"]');
 scrollSuave.init();
@@ -39,7 +38,9 @@ scrollAnimation.init();
 const dropdownMenu = new DropdownMenu("[data-dropdown]");
 dropdownMenu.init();
 
-initMenuMobile();
+const menuMobile = new MenuMobile('[data-menu="button"]', '[data-menu="list"]');
+menuMobile.init();
+
 initOperation();
 
 fetchAnimals("../../animalsapi.json", ".numbers-grid");


### PR DESCRIPTION
Converts the mobile menu from a standalone function to a class-based API, improving encapsulation and reuse. Adds default event handling (touchstart/click), binds the open handler, and introduces init/addMenuMobileEvents for a cleaner setup flow. Keeps outside-click closing behavior and active state management. Updates script to instantiate the class and call init, replacing the previous direct function usage.