### PR TITLE
Adds slide navigation helpers and auto-selects slide

### DIFF
--- a/css/slide.css
+++ b/css/slide.css
@@ -12,7 +12,3 @@
   max-width: 800px;
   margin: 0 20px;
 }
-
-.slide {
-    transform: translate3d(0px);
-}

--- a/js/modules/slide.js
+++ b/js/modules/slide.js
@@ -43,7 +43,7 @@ export default class Slide {
   }
 
   onEnd(event) {
-    const movetype = (event.type === "mouseup") ? "mousemove" : "touchmove";
+    const movetype = event.type === "mouseup" ? "mousemove" : "touchmove";
     this.wrapper.removeEventListener(movetype, this.onMove);
     this.dist.finalPosition = this.dist.movePosition;
   }
@@ -61,9 +61,41 @@ export default class Slide {
     this.onEnd = this.onEnd.bind(this);
   }
 
+  slidePosition(slide) {
+    const margin = this.wrapper.offsetWidth - slide.offsetWidth / 2;
+    return -(slide.offsetLeft - margin);
+  }
+
+  slidesConfig() {
+    this.slideArray = [...this.slide.children].map((element) => {
+      const position = this.slidePosition(element);
+      return {
+        position,
+        element,
+      };
+    });
+  }
+
+  slidesIndexNav(index) {
+    const last = this.slideArray.length - 1;
+    this.index = {
+      prev: index ? index - 1 : undefined,
+      active: index,
+      next: index === last ? undefined : index + 1,
+    };
+  }
+
+  changeSlide(index) {
+    const activeSlide = this.slideArray[index];
+    this.moveSlide(activeSlide.position);
+    this.slidesIndexNav(index);
+    this.dist.finalPosition = activeSlide.position;
+  }
+
   init() {
     this.bindEvents();
     this.addSlideEvents();
+    this.slidesConfig();
     return this;
   }
 }

--- a/js/script.js
+++ b/js/script.js
@@ -48,5 +48,7 @@ operation.init();
 const slide = new Slide(".slide", ".slide-wrapper");
 slide.init();
 
+slide.changeSlide(3);
+
 FetchAnimals("./animalsapi.json", ".numbers-grid");
 FetchBitcoin("https://blockchain.info/ticker", ".btc-price");


### PR DESCRIPTION
Implements a set of slide navigation utilities:
- computes each slide's position and caches configuration
- tracks prev/active/next indices and updates position accordingly
- enables changing to a specific slide programmatically
- initializes slide config during setup
- switches to a specific slide on startup for UX consistency

Also refactors movement type selection for cleaner syntax and removes an unused transform from CSS for cleaner styling